### PR TITLE
Added a job to copy vendors to separate tab w/ 1 line per commodity code

### DIFF
--- a/assets/abi_outreach_vendors/abi_outreach_vendors.etl.json
+++ b/assets/abi_outreach_vendors/abi_outreach_vendors.etl.json
@@ -33,6 +33,22 @@
         "append": true
       },
       "active": true
+    },
+    {
+      "type": "table_copy",
+      "source_location": {
+        "connection": "munis/munprod/mssqlgisadmin",
+        "schemaname": "amd",
+        "tablename": "mwbe_vendors_by_commodity_non_aggregated"
+      },
+      "target_location": {
+        "filename": "abi_outreach_vendors",
+        "connection": "bedrock-googlesheets",
+        "spreadsheetid": "1lm_LdZS6yhniDEuVGyaj3vdD7ACU8Eo_pCkmNr81TvA",
+        "range": "Vendors By Commodity Code!A2:Z",
+        "append": false
+      },
+      "active": true
     }
   ]
 }


### PR DESCRIPTION
Hey Jon,

This is a quick additional job to create a separate tab in the MWBE vendors spreadsheet with a line per commodity code for Christen to use to build an improved interface. I tested it by running in the etl_task_table_copy lambda separately.

Please review and, if ok, can we merge into dev, then production?

Eric